### PR TITLE
Rename `initialize` to `initializePackage`

### DIFF
--- a/lib/project-ring.coffee
+++ b/lib/project-ring.coffee
@@ -28,7 +28,7 @@ module.exports =
 		useNotifications: { type: 'boolean', default: true, description: 'Use notifications for important events' }
 
 	activate: (state) ->
-		setTimeout (=> @initialize state), 0
+		setTimeout (=> @initializePackage state), 0
 
 	consumeStatusBar: (statusBar) ->
 		return if @statusBarTile
@@ -55,7 +55,7 @@ module.exports =
 		@statusBarTile?.destroy()
 		@statusBarTile = null
 
-	initialize: (state) ->
+	initializePackage: (state) ->
 		return if globals.projectRingInitialized
 		globals.projectRingInitialized = true
 		@currentlySavingConfiguration = csonFile: false


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! :bow:

/cc: @vellerefond 